### PR TITLE
Hosts API exposed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 *.js.map
-*.js
 *.vpw
 *.vpj
 *.vpwhistu

--- a/hosts.d.ts
+++ b/hosts.d.ts
@@ -1,0 +1,33 @@
+
+import * as ts from 'typescript';
+import {RawSourceMap, Visitor} from "./index";
+
+export interface HostBase extends ts.CompilerHost {}
+export class HostBase implements HostBase {}
+
+
+export class ChainableHost extends HostBase {
+	setSource(source: ts.CompilerHost): void;
+}
+
+export function chainHosts(host0: ts.CompilerHost, ...chainableHosts: ChainableHost[]): ts.CompilerHost;
+
+export class AstCacheHost extends ChainableHost {
+	getSourceFile(fileName: string, languageVersion: ts.ScriptTarget, onError?: (message: string) => void): ts.SourceFile;
+}
+
+export class TransformationHost extends ChainableHost {
+	constructor(visitors: Visitor[], languageServiceProvider?: () => ts.LanguageService);
+	getSourceMap(fileName: string): RawSourceMap;
+	translateDiagnostic(diagnostic: ts.Diagnostic): ts.Diagnostic;
+}
+
+export interface SemanticHost extends ts.LanguageServiceHost, ts.CompilerHost, ts.DocumentRegistry {
+	getCancellationToken(): ts.CancellationToken;
+	getNewLine(): string;
+	useCaseSensitiveFileNames();
+}
+export class SemanticHost extends ChainableHost {
+	constructor(files: string[], compilerOptions?: ts.CompilerOptions);
+}
+

--- a/hosts.d.ts
+++ b/hosts.d.ts
@@ -31,8 +31,6 @@ export class SemanticHost extends ChainableHost {
 	constructor(files: string[], compilerOptions?: ts.CompilerOptions);
 }
 
-
-
 export class MultipleFilesHost extends HostBase {
 	constructor(resolutionHosts: ts.ModuleResolutionHost[], compilerOptions?: ts.CompilerOptions)
 	getSyntacticErrors(): ts.Diagnostic[];

--- a/hosts.d.ts
+++ b/hosts.d.ts
@@ -31,3 +31,16 @@ export class SemanticHost extends ChainableHost {
 	constructor(files: string[], compilerOptions?: ts.CompilerOptions);
 }
 
+
+
+export class MultipleFilesHost extends HostBase {
+	constructor(resolutionHosts: ts.ModuleResolutionHost[], compilerOptions?: ts.CompilerOptions)
+	getSyntacticErrors(): ts.Diagnostic[];
+}
+
+export class SingleFileHost extends HostBase {
+	constructor(ast: ts.SourceFile);
+	public output: string;
+	public sourceMap: RawSourceMap;
+}
+

--- a/hosts.js
+++ b/hosts.js
@@ -1,0 +1,6 @@
+var hosts = require('./dist/src/hosts');
+var hostsBase = require('./dist/src/hosts-base');
+module.exports = hosts;
+module.exports.HostBase = hostsBase.HostBase;
+module.exports.ChainableHost = hostsBase.ChainableHost;
+module.exports.chainHosts = hostsBase.chainHosts;

--- a/hosts.js
+++ b/hosts.js
@@ -1,6 +1,9 @@
+var chainableHosts = require('./dist/src/chainable-hosts');
 var hosts = require('./dist/src/hosts');
 var hostsBase = require('./dist/src/hosts-base');
-module.exports = hosts;
+module.exports = chainableHosts;
+module.exports.MultipleFilesHost = hosts.MultipleFilesHost;
+module.exports.SingleFileHost = hosts.SingleFileHost;
 module.exports.HostBase = hostsBase.HostBase;
 module.exports.ChainableHost = hostsBase.ChainableHost;
 module.exports.chainHosts = hostsBase.chainHosts;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,17 @@
 import * as ts from "typescript";
-import {RawSourceMap} from "source-map";
+
+interface StartOfSourceMap {
+	file?: string;
+	sourceRoot?: string;
+}
+
+export interface RawSourceMap extends StartOfSourceMap {
+	version: string;
+	sources: Array<string>;
+	names: Array<string>;
+	sourcesContent?: string;
+	mappings: string;
+}
 
 export interface Replacement {
 	start: number;
@@ -46,6 +58,8 @@ export interface ApplyVisitorResult {
 
 export function applyVisitor(source: string, visitor: Visitor): ApplyVisitorResult;
 
+export function applyVisitorOnHostedSource(file: string, visitors: Visitor[], host: ts.CompilerHost): string;
+
 export function applyVisitorOnAst(ast: ts.SourceFile, visitor: Visitor): ApplyVisitorResult;
 
 export interface ValidatorConfig {
@@ -58,4 +72,6 @@ export function validateAll(files: string[], config: ValidatorConfig): ts.Diagno
 
 export function traverseAst(root: ts.Node, visitor: Visitor, context: VisitorContext): boolean;
 
-export function applySemanticVisitors(file: string, visitors: Visitor[], resolutionHosts: ts.ModuleResolutionHost[]): string;
+export type SemanticHost = ts.LanguageServiceHost & ts.CompilerHost & ts.DocumentRegistry;
+
+export function createSemanticHost(files: string[], ...resolutionHosts: ts.ModuleResolutionHost[]): SemanticHost;

--- a/index.d.ts
+++ b/index.d.ts
@@ -57,3 +57,5 @@ export interface ValidatorConfig {
 export function validateAll(files: string[], config: ValidatorConfig): ts.Diagnostic[];
 
 export function traverseAst(root: ts.Node, visitor: Visitor, context: VisitorContext): boolean;
+
+export function applySemanticVisitors(file: string, visitors: Visitor[], resolutionHosts: ts.ModuleResolutionHost[]): string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -71,7 +71,3 @@ export interface ValidatorConfig {
 export function validateAll(files: string[], config: ValidatorConfig): ts.Diagnostic[];
 
 export function traverseAst(root: ts.Node, visitor: Visitor, context: VisitorContext): boolean;
-
-export type SemanticHost = ts.LanguageServiceHost & ts.CompilerHost & ts.DocumentRegistry;
-
-export function createSemanticHost(files: string[], ...resolutionHosts: ts.ModuleResolutionHost[]): SemanticHost;

--- a/src/apply-visitor.ts
+++ b/src/apply-visitor.ts
@@ -5,6 +5,8 @@ import { traverseAst } from './traverse-ast';
 import { Visitor } from "./visitor";
 import { Action, MutableSourceCode } from './mutable-source-code';
 import { TranspilerContext } from "./transpiler-context";
+import {SemanticHost} from "./chainable-hosts";
+import {VisitorBasedTransformer, CodeTransformer} from "./transformer";
 
 export interface ApplyVisitorResult {
     file: ts.SourceFile,
@@ -18,6 +20,19 @@ export function applyVisitor(source: string, visitor: Visitor): ApplyVisitorResu
     const ast = ts.createSourceFile("test.ts", source, defaultCompilerOptions.target, true);
     return applyVisitorOnAst(ast, visitor);
 }
+
+export function applyVisitorOnHostedSource(file: string, visitors: Visitor[], host: ts.CompilerHost): string {
+	const langService = host instanceof SemanticHost ? ts.createLanguageService(host, host) : null;
+	const transformer: CodeTransformer = new VisitorBasedTransformer(visitors, () => langService);
+	const ast: ts.SourceFile = host.getSourceFile(file, defaultCompilerOptions.target);
+	if(ast) {
+		const mutableSourceCode: MutableSourceCode = transformer.transform(ast);
+		return mutableSourceCode.code;
+	} else {
+		return null;
+	}
+}
+
 
 export function applyVisitorOnAst(ast: ts.SourceFile, visitor: Visitor): ApplyVisitorResult {
 

--- a/src/chainable-hosts.ts
+++ b/src/chainable-hosts.ts
@@ -160,9 +160,3 @@ export class SemanticHost extends ChainableHost implements ts.LanguageServiceHos
 	}
 }
 
-export function createSemanticHost(files: string[], ...resolutionHosts: ts.ModuleResolutionHost[]): SemanticHost {
-	const sourceHost = new MultipleFilesHost(resolutionHosts);
-	const astCache = new AstCacheHost();
-	const semanticHost = new SemanticHost(files);
-	return <SemanticHost>chainHosts(sourceHost, astCache, semanticHost);
-}

--- a/src/hosts.ts
+++ b/src/hosts.ts
@@ -3,6 +3,7 @@
 
 import * as ts from 'typescript';
 import {HostBase} from "./hosts-base";
+import {defaultCompilerOptions} from "./configuration";
 
 
 function fileExtensionIs(path: string, extension: string): boolean {
@@ -19,7 +20,7 @@ export class MultipleFilesHost extends HostBase implements ts.CompilerHost {
 
 	constructor(
 		private _resolutionHosts: ts.ModuleResolutionHost[],
-		private _compilerOptions: ts.CompilerOptions
+		private _compilerOptions: ts.CompilerOptions = defaultCompilerOptions
 	) {
 		super();
 	}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,9 @@
 /// <reference path="../typings/source-map/source-map.d.ts"/>
 /// <reference path="../typings/node/node.d.ts" />
 
-export { transpile, TranspilerOutput, TranspilerConfig, ValidatorConfig, validateAll, applySemanticVisitors } from './transpile';
+export { transpile, TranspilerOutput, TranspilerConfig, ValidatorConfig, validateAll } from './transpile';
 export { Visitor, VisitorContext } from "./visitor";
-export { applyVisitor, applyVisitorOnAst } from "./apply-visitor";
+export { applyVisitor, applyVisitorOnAst, applyVisitorOnHostedSource } from "./apply-visitor";
 export { MultipleFilesHost } from "./hosts";
 export { traverseAst } from "./traverse-ast";
+export { createSemanticHost } from './chainable-hosts';

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,4 +6,3 @@ export { Visitor, VisitorContext } from "./visitor";
 export { applyVisitor, applyVisitorOnAst, applyVisitorOnHostedSource } from "./apply-visitor";
 export { MultipleFilesHost } from "./hosts";
 export { traverseAst } from "./traverse-ast";
-export { createSemanticHost } from './chainable-hosts';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 /// <reference path="../typings/source-map/source-map.d.ts"/>
 /// <reference path="../typings/node/node.d.ts" />
 
-export { transpile, TranspilerOutput, TranspilerConfig, ValidatorConfig, validateAll } from './transpile';
+export { transpile, TranspilerOutput, TranspilerConfig, ValidatorConfig, validateAll, applySemanticVisitors } from './transpile';
 export { Visitor, VisitorContext } from "./visitor";
 export { applyVisitor, applyVisitorOnAst } from "./apply-visitor";
 export { MultipleFilesHost } from "./hosts";

--- a/test/e2e.validate-all.spec.ts
+++ b/test/e2e.validate-all.spec.ts
@@ -3,7 +3,6 @@ import * as tspoon from '../src/index';
 import * as ts from 'typescript';
 import {ValidatorConfig} from "../src/transpile";
 import {VisitorContext} from "../index";
-import {VisitorBasedTransformer} from "../src/transformer";
 import {Visitor} from "../src/visitor";
 import {MockModule} from "../test-kit/mocks/resolution-hosts";
 


### PR DESCRIPTION
Enables us to use tspoon in the following way:

``` tsx
import * as tspoon from 'tspoon/hosts';

const sourceHost = new tspoon.MultipleFilesHost(resolutionHosts);
const astCache = new tspoon.AstCacheHost();
const semanticHost = new tspoon.SemanticHost(files);
tspoon.chainHosts(sourceHost, astCache, semanticHost);
ts.createLanguageService(semanticHost, semanticHost);
// etc.
```
