### PR TITLE
Fix TS2 crashing when looking for our default BaseHost lib.d.ts

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -10,5 +10,6 @@ export const defaultCompilerOptions:ts.CompilerOptions = {
     sourceMap: true,
     preserveConstEnums: true,
     inlineSources: true,
-    emitDecoratorMetadata: false
+    emitDecoratorMetadata: false,
+    noLib: true
 };


### PR DESCRIPTION
TypeScript 2 will crash for our lib.d.ts value