### PR TITLE
Export chainable hosts as well

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,5 +2,6 @@ export { transpile, TranspilerOutput, TranspilerConfig, ValidatorConfig, validat
 export { Visitor, VisitorContext } from './visitor';
 export { traverseAst } from './traverse-ast';
 export * from './apply-visitor';
-export * from './hosts';
 export * from './hosts-base';
+export * from './hosts';
+export * from './chainable-hosts';


### PR DESCRIPTION
(to allow getting rid of manually-written hosts.d.ts)