### PR TITLE
Additional hooks into the Transpile process

### DIFF
--- a/src/mutable-source-code.ts
+++ b/src/mutable-source-code.ts
@@ -1,7 +1,7 @@
-import ts = require('typescript');
+import * as ts from 'typescript';
 import { RawSourceMap, SourceMapConsumer, SourceMapGenerator, MappedPosition } from 'source-map';
 import * as traverse from './traverse-ast';
-import MagicString = require('magic-string');
+import * as MagicString from 'magic-string';
 import binarySearch from './binary-search';
 
 export abstract class MappedAction {

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -1,4 +1,4 @@
-import ts = require('typescript');
+import * as ts from 'typescript';
 import { Visitor } from './visitor';
 import { TranspilerContext } from './transpiler-context';
 import { traverseAst } from './traverse-ast';

--- a/src/transpile.ts
+++ b/src/transpile.ts
@@ -1,4 +1,4 @@
-import ts = require('typescript');
+import * as ts from 'typescript';
 import { SingleFileHost, MultipleFilesHost } from './hosts';
 import { traverseAst } from './traverse-ast';
 import { MutableSourceCode } from './mutable-source-code';

--- a/src/transpile.ts
+++ b/src/transpile.ts
@@ -52,7 +52,7 @@ function getParserErrors(sourceFile: ts.SourceFile): ts.Diagnostic[] {
 }
 
 
-export function transpile(content: string, config: TranspilerConfig): TranspilerOutput {
+export function transpile(content: string | ts.SourceFile, config: TranspilerConfig): TranspilerOutput {
 
     // The context may contain compiler options and a list of visitors.
     // If it doesn't, we use the default as defined in ./configuration.ts
@@ -65,7 +65,9 @@ export function transpile(content: string, config: TranspilerConfig): Transpiler
 
     // Then we let TypeScript parse it into an AST
 
-    const ast = ts.createSourceFile(fileName, content, compilerOptions.target, true);
+    const ast = typeof content === 'string'
+        ? ts.createSourceFile(fileName, content, compilerOptions.target, true)
+        : content;
     const parserErrors = getParserErrors(ast);
     if (parserErrors.length > 0) {
         return {

--- a/src/transpiler-context.ts
+++ b/src/transpiler-context.ts
@@ -1,4 +1,4 @@
-import ts = require('typescript');
+import * as ts from 'typescript';
 import { MutableSourceCode, Action, ReplaceAction } from './mutable-source-code';
 import { Visitor, VisitorContext } from './visitor';
 import { FastAppendAction } from './mutable-source-code';

--- a/src/traverse-ast.ts
+++ b/src/traverse-ast.ts
@@ -1,4 +1,4 @@
-import ts = require('typescript');
+import * as ts from 'typescript';
 import { Visitor, VisitorContext } from './visitor';
 
 function descend(node: ts.Node, context: VisitorContext) {

--- a/src/visitor.ts
+++ b/src/visitor.ts
@@ -1,4 +1,4 @@
-import ts = require('typescript');
+import * as ts from 'typescript';
 import { Action } from './mutable-source-code';
 
 /**

--- a/typings/magic-string.d.ts
+++ b/typings/magic-string.d.ts
@@ -3,88 +3,85 @@
 // Definitions by: Amir Arad <https://github.com/amir-arad>
 /// <reference types="source-map" />
 
-declare module 'magic-string' {
-
-    interface SourceMap extends sourceMap.RawSourceMap {
-        toString(): string;
-        toUrl(): string;
-    }
-
-    interface Exclusion {
-        0: number;
-        1: number;
-    }
-
-    interface IndentOptions {
-        exclude?: Exclusion | Array<Exclusion>;
-        indentStart?: boolean;
-    }
-
-    interface MapOptions {
-        file?: string;
-        source?: string;
-        includeContent?: boolean;
-        hires?: boolean;
-    }
-
-    interface MagicStringOptions {
-        filename?: string;
-        indentExclusionRanges?: number[];
-    }
-
-    class MagicString {
-        constructor(string: string, options?: MagicStringOptions);
-        addSourcemapLocation(index: number): void;
-        append(content: string): MagicString;
-        appendLeft(index: number, content: string): MagicString;
-        appendRight(index: number, content: string): MagicString;
-        clone(): MagicString;
-        generateMap(options?: MapOptions): SourceMap;
-        getIndentString(): string;
-        indent(prefix: string, options?: IndentOptions): MagicString;
-        move(start: number, end: number, newIndex: number): MagicString;
-        overwrite(start: number, end: number, content?: string, storeName?: boolean): MagicString;
-        prepend(content: string): MagicString;
-        prependLeft(index: number, content: string): MagicString;
-        prependRight(index: number, content: string): MagicString;
-        remove(start: number, end: number): MagicString;
-        slice(start: number, end: number): MagicString;
-        snip(start: number, end: number): MagicString;
-        toString(): string;
-        trim(charType?: string): MagicString;
-        trimStart(charType?: string): MagicString;
-        trimEnd(charType?: string): MagicString;
-        trimLines(): MagicString;
-        static Bundle;
-    }
-
-    interface BundleOptions {
-        intro?: string;
-        outro?: string;
-        separator?: string;
-    }
-
-    interface BundleSource {
-        filename?: string;
-        separator?: string;
-        content: MagicString;
-    }
-
-    class Bundle {
-        constructor(options?: BundleOptions);
-        addSource(source: BundleSource | MagicString): Bundle;
-        append(string: string, options?: { seperator?: string }): Bundle;
-        clone(): Bundle;
-        generateMap(options: MapOptions): SourceMap;
-        getIndentString(): string;
-        indent(indentStr: string): Bundle;
-        prepend(content: string): Bundle;
-        toString(): string;
-        trim(charType: string): Bundle;
-        trimStart(charType: string): Bundle;
-        trimEnd(charType: string): Bundle;
-        trimLines(): Bundle;
-    }
-
-    export = MagicString;
+interface SourceMap extends sourceMap.RawSourceMap {
+    toString(): string;
+    toUrl(): string;
 }
+
+interface Exclusion {
+    0: number;
+    1: number;
+}
+
+interface IndentOptions {
+    exclude?: Exclusion | Array<Exclusion>;
+    indentStart?: boolean;
+}
+
+interface MapOptions {
+    file?: string;
+    source?: string;
+    includeContent?: boolean;
+    hires?: boolean;
+}
+
+interface MagicStringOptions {
+    filename?: string;
+    indentExclusionRanges?: number[];
+}
+
+declare class MagicString {
+    constructor(string: string, options?: MagicStringOptions);
+    addSourcemapLocation(index: number): void;
+    append(content: string): MagicString;
+    appendLeft(index: number, content: string): MagicString;
+    appendRight(index: number, content: string): MagicString;
+    clone(): MagicString;
+    generateMap(options?: MapOptions): SourceMap;
+    getIndentString(): string;
+    indent(prefix: string, options?: IndentOptions): MagicString;
+    move(start: number, end: number, newIndex: number): MagicString;
+    overwrite(start: number, end: number, content?: string, storeName?: boolean): MagicString;
+    prepend(content: string): MagicString;
+    prependLeft(index: number, content: string): MagicString;
+    prependRight(index: number, content: string): MagicString;
+    remove(start: number, end: number): MagicString;
+    slice(start: number, end: number): MagicString;
+    snip(start: number, end: number): MagicString;
+    toString(): string;
+    trim(charType?: string): MagicString;
+    trimStart(charType?: string): MagicString;
+    trimEnd(charType?: string): MagicString;
+    trimLines(): MagicString;
+    static Bundle;
+}
+
+interface BundleOptions {
+    intro?: string;
+    outro?: string;
+    separator?: string;
+}
+
+interface BundleSource {
+    filename?: string;
+    separator?: string;
+    content: MagicString;
+}
+
+declare class Bundle {
+    constructor(options?: BundleOptions);
+    addSource(source: BundleSource | MagicString): Bundle;
+    append(string: string, options?: { seperator?: string }): Bundle;
+    clone(): Bundle;
+    generateMap(options: MapOptions): SourceMap;
+    getIndentString(): string;
+    indent(indentStr: string): Bundle;
+    prepend(content: string): Bundle;
+    toString(): string;
+    trim(charType: string): Bundle;
+    trimStart(charType: string): Bundle;
+    trimEnd(charType: string): Bundle;
+    trimLines(): Bundle;
+}
+
+export = MagicString;


### PR DESCRIPTION
In order to avoid using globals, I found that I needed to store custom data on either the SourceFile or the VisitorContext, as both are freely available in each call to Visitor#visit.
